### PR TITLE
Do not depend on org mode

### DIFF
--- a/butler.el
+++ b/butler.el
@@ -130,7 +130,7 @@
                              (deferred:nextc it
                                (lambda (buf)
                                  (with-current-buffer buf
-                                   (beginning-of-buffer)
+                                   (goto-char (point-min))
                                    (search-forward "{")
                                    (let* ((data (buffer-substring (- (point) 1) (point-max)))
                                           (parsed (json-read-from-string data)))


### PR DESCRIPTION
org-link-unescape function comes from org mode. Butler doesn't declare dependency on org mode and doesn't load it. Is the result one get errors if he tries to use butler on emacs without org mode.

This pull request replaces use of org-link-unescape with url-unhex-string which comes form url package which butler already uses.

This pull request  also replaces use of beginning-of-buffer with goto-char which is faster according to emacs docs.

Please let me know if there are any problems.

Thanks!
