### PR TITLE
Add job information retrieval

### DIFF
--- a/butler-servers.el
+++ b/butler-servers.el
@@ -83,6 +83,10 @@
 (defun get-job (server name)
   (gethash name (gethash 'jobs server)))
 
+(defun get-url (name &optional server)
+  (if server
+      (get-in butler-hash (list server 'jobs name 'url))
+    (get-in butler-hash (list (find-current-server name) 'jobs name 'url))))
 
 (provide 'butler-servers)
 

--- a/butler-util.el
+++ b/butler-util.el
@@ -85,6 +85,8 @@
     (colorize-dot (subseq color 0 -6)))
    (t (concat "Unknown: " "'" color "' "))))
 
+(defun build-auth-headers (auth)
+  `(("Authorization" . ,auth)))
 
 ;;; Code:
 (provide 'butler-util)

--- a/butler-util.el
+++ b/butler-util.el
@@ -85,8 +85,28 @@
     (colorize-dot (subseq color 0 -6)))
    (t (concat "Unknown: " "'" color "' "))))
 
+(defun colorize-status (status)
+  (cond
+   ((string= status "ABORTED")
+    (propertize "●" 'face 'butler-aborted))
+   ((string= status "FAILURE")
+    (propertize "●" 'face 'butler-failure))
+   ((string= status "SUCCESS")
+    (propertize "●" 'face 'butler-success))))
+
+(defun get-in (hash keys)
+  (reduce
+   (lambda (a b) (gethash b a))
+   keys :initial-value hash))
+
 (defun build-auth-headers (auth)
   `(("Authorization" . ,auth)))
+
+(defun strip-headers (http-buf)
+  (with-current-buffer http-buf
+    (search-forward "\n\n")
+    (delete-region (point-min) (point))
+    http-buf))
 
 ;;; Code:
 (provide 'butler-util)

--- a/butler.el
+++ b/butler.el
@@ -71,7 +71,6 @@
     (define-key map (kbd "q") 'butler-quit)
     map))
 
-
 (define-derived-mode butler-mode fundamental-mode "Butler"
   "A major mode for interacting with various CI servers"
   (use-local-map butler-mode-map)
@@ -290,11 +289,6 @@
                 (insert "\n"))))
           jobs)
     (funcall callback)))
-
-
-
-
-
 
 (defun draw-butler (buffer callback)
   (with-current-buffer buffer

--- a/butler.el
+++ b/butler.el
@@ -226,7 +226,7 @@
            (job (get-job server job-name))
            (url (gethash 'url job))
            (auth (gethash 'auth server))
-           (url-request-extra-headers `(("Authorization" . ,auth))))
+           (url-request-extra-headers (build-auth-headers auth)))
       (if (and url auth)
           (deferred:$
             (deferred:url-retrieve (concat url "build/"))

--- a/butler.el
+++ b/butler.el
@@ -39,7 +39,10 @@
 (require 'butler-util)
 
 (defcustom butler-auto-refresh t
-  "Set to non-nil to auto-refresh the buffer.  When this is non-nil, the butler status buffer is refreshed at regular intervals specified by `butler-auto-refresh-interval'.  The buffer is never refreshed when it is in the background."
+  "Set to non-nil to auto-refresh the buffer.  When this is
+non-nil, the butler status buffer is refreshed at regular
+intervals specified by `butler-auto-refresh-interval'.  The
+buffer is never refreshed when it is in the background."
   :type 'boolean
   :group 'butler
   :set (lambda (symbol value)
@@ -48,7 +51,12 @@
            (butler-manage-refresh-timer))))
 
 (defcustom butler-auto-refresh-interval 5
-  "Specifies the number of seconds to wait between refreshing the butler status buffer.  Setting this to any number less than 1 will be treated as a 1 second interval.  Auto-refresh can be turned on or off with the `butler-auto-refresh' variable.  Refresh can be toggled by pressing 'a' in the butler status buffer."
+  "Specifies the number of seconds to wait between refreshing the
+butler status buffer.  Setting this to any number less than 1
+will be treated as a 1 second interval.  Auto-refresh can be
+turned on or off with the `butler-auto-refresh' variable.
+Refresh can be toggled by pressing 'a' in the butler status
+buffer."
   :type 'integer
   :group 'butler
   :set (lambda (symbol value)
@@ -89,11 +97,14 @@
   map))
 
 (defun butler-toggle-auto-refresh ()
-  "Toggles whether the butler status buffer refreshes automatically.  This is driven by the `butler-auto-refresh' and `butler-auto-refresh-interval' variables, which can be customized with M-x customize-group RET butler RET"
+  "Toggles whether the butler status buffer refreshes
+automatically.  This is driven by the `butler-auto-refresh' and
+`butler-auto-refresh-interval' variables, which can be customized
+with M-x customize-group RET butler RET"
   (interactive)
   (setq butler-auto-refresh (not butler-auto-refresh))
   (message (concat "Auto-refresh " (if butler-auto-refresh "enabled." "disabled.")))
-  (butler-manage-refresh-timer))
+  (butler-manage-refresh-timer))-
 
 (defun butler-manage-refresh-timer ()
   (cancel-function-timers 'butler-timer-refresh)

--- a/butler.el
+++ b/butler.el
@@ -167,7 +167,7 @@
 
 (defun parse-jobs (data)
   (let* ((parsed (json-read-from-string data))
-	 (jobs (cdr (assoc 'jobs parsed))))
+         (jobs (cdr (assoc 'jobs parsed))))
     jobs))
 
 


### PR DESCRIPTION
:rotating_light: WIP :rotating_light: 

I'm submitting this as a WIP to get feedback and to elicit discussion about the overall architecture of the code.

1) The HTTP callback business has to go.
2) Retrieving the authentication information before each HTTP call is annoying.
3) The global hash map makes for an awkward api (Ref #https://github.com/AshtonKem/Butler/issues/11)
4) Pertaining to 2+3, maybe some kind of proper object (defstruct?) could be used for better access to relevant information?

As for the code in this PR -- please review. I want to provide a better view of the actual job data, opinions welcome there.

Questions:

Should the information query automatically query the last 10 or so jobs (each a new HTTP request!) or not? Is there a way to get this information in one go?
